### PR TITLE
For Issue 394 fix(con-author): Prevent replacement errors

### DIFF
--- a/www/js/con-author.js
+++ b/www/js/con-author.js
@@ -1434,10 +1434,15 @@ define([
 			//var slotMap = this.getSchemaProperty("Mapping", schema);
 			//retrieve the generic equation always when updating to replace the equation
 			var equation = this.getSchemaProperty("Equation", this.schema);
+
+			// add $ to all strings in the generic equation to keep replacement accurate
+			for(var varKey in this.slotMap){
+				equation = equation.replace(varKey,"$"+varKey)
+			}
 			for(var varKey in this.slotMap){
 				var updatedValue = dom.byId("holder"+this.schema+this.currentID+this.slotMap[varKey]).value;
-				console.log("replacing", varKey, updatedValue);
-				equation = equation.replace(varKey, updatedValue);
+				console.log("replacing", varKey, "\'"+updatedValue+"\'");
+				equation = equation.replace("$"+varKey, updatedValue);
 			}
 			registry.byId(this.controlMap.equation).set("value",equation);
 			this.equation = equation;


### PR DESCRIPTION
Equation updating was failing in the case where a variable prefix was used in different slot.  For instance, the user should be able to put an existing variable PB1 into the W slot of a part whole to make "PB1 = PA2 + PB2".  However the original code would replace the W first, then later replace all instances of PB in the string (not just the last one).  

The fix I made was to modify the template after we get it from the schema table by adding a special character the user can't enter to make the template items unique.  So "W = PA + PB" becomes "$W = $PA + $PB".  We then replace the new $template instead of the template string itself. 